### PR TITLE
Add coin info to markets page + update site description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
 		<link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#000000" />
-		<meta name="description" content="Web site created using create-react-app" />
+		<meta name="description" content="Compound info is a dashboard for historical Compound.finance interest rates" />
 		<!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -6,6 +6,7 @@ import ProgressRing from 'components/ProgressRing';
 import Row from 'components/Row';
 import Column from 'components/Column';
 import TooltipText from 'components/TooltipText';
+import { StyledExternalInfoLink } from 'theme/components';
 
 const Card = styled.div`
 	display: flex;
@@ -49,14 +50,18 @@ export function StatCard({ title, value, unit, tooltipContent }) {
 	);
 }
 
-export function CoinInfoCard({ title, value }) {
+export function CoinInfoCard({ value, whitepaper, website, twitter, coingecko }) {
 	return (
 		<StyledStatCard>
 			<Row>
-				<CardHeader>{title}</CardHeader>
-			</Row>
-			<Row>
 				<Typography.body>{value}</Typography.body>
+			</Row>
+			<br />
+			<Row>
+				<StyledExternalInfoLink href={whitepaper} content={'Whitepaper ↗'} />
+				<StyledExternalInfoLink href={website} content={'Website ↗'} />
+				<StyledExternalInfoLink href={twitter} content={'Twitter ↗'} />
+				<StyledExternalInfoLink href={coingecko} content={'Coingecko ↗'} />
 			</Row>
 		</StyledStatCard>
 	);

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -49,6 +49,19 @@ export function StatCard({ title, value, unit, tooltipContent }) {
 	);
 }
 
+export function CoinInfoCard({ title, value }) {
+	return (
+		<StyledStatCard>
+			<Row>
+				<CardHeader>{title}</CardHeader>
+			</Row>
+			<Row>
+				<Typography.body>{value}</Typography.body>
+			</Row>
+		</StyledStatCard>
+	);
+}
+
 // progressValue is a number from 0 to 1
 export function ProgressCard({ title, value, unit, size, progressValue, tooltipContent }) {
 	const formattedValue = formatNumber(value, unit);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -12,17 +12,23 @@ export const COINS = [
 	{
 		name: 'BAT',
 		imgSrc: batSvg,
-		desc: `Basic Attention Token (BAT) is a token that powers Brave's blockchain-based digital 
-		advertising platform.
-		`,
+		desc: `Basic Attention Token (BAT) is a token that powers Brave's blockchain-based digital
+		advertising platform.`,
+		whitepaper: 'https://basicattentiontoken.org/static-assets/documents/BasicAttentionTokenWhitePaper-4.pdf',
+		website: 'https://basicattentiontoken.org/',
+		twitter: 'https://twitter.com/attentiontoken',
+		coingecko: 'https://www.coingecko.com/en/coins/basic-attention-token',
 	},
 	{
 		name: 'COMP',
 		imgSrc: compSvg,
 		desc: `Compound (COMP) is a token that enables community governance of the
 		Compound protocol. COMP token holders and their delegates can also debate,
-		propose, and vote on changes to the protocol.
-		`,
+		propose, and vote on changes to the protocol.`,
+		whitepaper: 'https://compound.finance/documents/Compound.Whitepaper.pdf',
+		website: 'https://compound.finance/',
+		twitter: 'https://twitter.com/compoundfinance',
+		coingecko: 'https://www.coingecko.com/en/coins/compound',
 	},
 	{
 		name: 'DAI',
@@ -31,6 +37,10 @@ export const COINS = [
 		value of $1.00 USD. Unlike centralized stablecoins, Dai isn't backed by US
 		dollars in a bank account. Instead, it’s backed by collateral on the Maker
 		platform.`,
+		whitepaper: 'https://makerdao.com/en/whitepaper/#abstract',
+		website: 'https://makerdao.com/en/',
+		twitter: 'https://twitter.com/MakerDAO',
+		coingecko: 'https://www.coingecko.com/en/coins/dai',
 	},
 	{
 		name: 'ETH',
@@ -38,39 +48,55 @@ export const COINS = [
 		desc: `Ethereum is a decentralized computing platform that uses ETH
 		(also called Ether) to pay transaction fees (or “gas”). Developers can use
 		Ethereum to run decentralized applications (like Compound) and issue new
-		crypto assets, known as Ethereum tokens (ERC-20).
-		`,
+		crypto assets, known as Ethereum tokens (ERC-20).`,
+		whitepaper: 'https://ethereum.org/en/whitepaper/',
+		website: 'https://ethereum.org/en/',
+		twitter: 'https://twitter.com/ethereum?lang=en',
+		coingecko: 'https://www.coingecko.com/en/coins/ethereum',
 	},
 	{
 		name: 'UNI',
 		imgSrc: uniSvg,
 		desc: `Uniswap (UNI) is a token that powers governance on Uniswap, an
 		automated liquidity provider that’s designed to make it easy to exchange
-		Ethereum (ERC-20) tokens.
-		`,
+		Ethereum (ERC-20) tokens.`,
+		whitepaper: 'https://uniswap.org/whitepaper-v3.pdf',
+		website: 'http://uniswap.org/',
+		twitter: 'https://twitter.com/Uniswap',
+		coingecko: 'https://www.coingecko.com/en/coins/uniswap',
 	},
 	{
 		name: 'ZRX',
 		imgSrc: zrxSvg,
 		desc: `ZRX is a token that is used to power the 0x protocol.
 		The protocol itself is designed to allow Ethereum tokens to be traded at a
-		low cost directly from your wallet.
-		`,
+		low cost directly from your wallet.`,
+		whitepaper: 'https://0x.org/pdfs/0x_white_paper.pdf',
+		website: 'https://0x.org/',
+		twitter: 'https://twitter.com/0xProject',
+		coingecko: 'https://www.coingecko.com/en/coins/0x',
 	},
 	{
 		name: 'USDC',
 		imgSrc: usdcSvg,
 		desc: `USD Coin (USDC) is a stablecoin fully backed by the US dollar and
 		developed by the CENTRE consortium. USDC can be exchanged for dollars
-		1:1 on Coinbase and other exchanges`,
+		1:1 on Coinbase and other exchanges.`,
+		whitepaper: 'https://f.hubspotusercontent30.net/hubfs/9304636/PDF/centre-whitepaper.pdf',
+		website: 'https://www.circle.com/en/usdc',
+		twitter: 'https://twitter.com/circlepay',
+		coingecko: 'https://www.coingecko.com/en/coins/usd-coin',
 	},
 	{
 		name: 'USDT',
 		imgSrc: usdtSvg,
 		desc: `Tether (USDT) is a stablecoin that is pegged to the value of a U.S.
 		dollar. Tether’s issuer claims that USDT is backed by bank reserves and
-		loans which match or exceed the value of USDT in circulation.
-		`,
+		loans which match or exceed the value of USDT in circulation.`,
+		whitepaper: 'https://tether.to/wp-content/uploads/2016/06/TetherWhitePaper.pdf',
+		website: 'https://tether.to/',
+		twitter: 'https://twitter.com/Tether_to',
+		coingecko: 'https://www.coingecko.com/en/coins/tether',
 	},
 	{
 		name: 'WBTC',
@@ -78,16 +104,22 @@ export const COINS = [
 		desc: `Wrapped Bitcoin (WBTC) is an Ethereum token that is intended to 
 		represent Bitcoin (BTC) on the Ethereum blockchain. This version of WBTC on 
 		Compound is no longer being supported, with the community migrating 
-		to WBTC2.
-		`,
+		to WBTC2.`,
+		whitepaper: 'https://wbtc.network/assets/wrapped-tokens-whitepaper.pdf',
+		website: 'https://wbtc.network/',
+		twitter: 'https://twitter.com/wrappedbtc',
+		coingecko: 'https://www.coingecko.com/en/coins/wrapped-bitcoin',
 	},
 	{
 		name: 'WBTC2',
 		imgSrc: wbtcSvg,
 		desc: `Wrapped Bitcoin (WBTC2) is an Ethereum token that is intended to 
 		represent Bitcoin (BTC) on the Ethereum blockchain. 
-		This version of WBTC is still being actively supported on Compound.
-		`,
+		This version of WBTC is still being actively supported on Compound.`,
+		whitepaper: 'https://wbtc.network/assets/wrapped-tokens-whitepaper.pdf',
+		website: 'https://wbtc.network/',
+		twitter: 'https://twitter.com/wrappedbtc',
+		coingecko: 'https://www.coingecko.com/en/coins/wrapped-bitcoin',
 	},
 ];
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,16 +9,86 @@ import usdtSvg from 'assets/coins/USDT.svg';
 import wbtcSvg from 'assets/coins/WBTC.svg';
 
 export const COINS = [
-	{ name: 'BAT', imgSrc: batSvg },
-	{ name: 'COMP', imgSrc: compSvg },
-	{ name: 'DAI', imgSrc: daiSvg },
-	{ name: 'ETH', imgSrc: ethSvg },
-	{ name: 'UNI', imgSrc: uniSvg },
-	{ name: 'ZRX', imgSrc: zrxSvg },
-	{ name: 'USDC', imgSrc: usdcSvg },
-	{ name: 'USDT', imgSrc: usdtSvg },
-	{ name: 'WBTC', imgSrc: wbtcSvg },
-	{ name: 'WBTC2', imgSrc: wbtcSvg },
+	{
+		name: 'BAT',
+		imgSrc: batSvg,
+		desc: `Basic Attention Token (BAT) is a token that powers Brave's blockchain-based digital 
+		advertising platform.
+		`,
+	},
+	{
+		name: 'COMP',
+		imgSrc: compSvg,
+		desc: `Compound (COMP) is a token that enables community governance of the
+		Compound protocol. COMP token holders and their delegates can also debate,
+		propose, and vote on changes to the protocol.
+		`,
+	},
+	{
+		name: 'DAI',
+		imgSrc: daiSvg,
+		desc: `Dai (DAI) is a decentralized stablecoin that attempts to maintain a
+		value of $1.00 USD. Unlike centralized stablecoins, Dai isn't backed by US
+		dollars in a bank account. Instead, it’s backed by collateral on the Maker
+		platform.`,
+	},
+	{
+		name: 'ETH',
+		imgSrc: ethSvg,
+		desc: `Ethereum is a decentralized computing platform that uses ETH
+		(also called Ether) to pay transaction fees (or “gas”). Developers can use
+		Ethereum to run decentralized applications (like Compound) and issue new
+		crypto assets, known as Ethereum tokens (ERC-20).
+		`,
+	},
+	{
+		name: 'UNI',
+		imgSrc: uniSvg,
+		desc: `Uniswap (UNI) is a token that powers governance on Uniswap, an
+		automated liquidity provider that’s designed to make it easy to exchange
+		Ethereum (ERC-20) tokens.
+		`,
+	},
+	{
+		name: 'ZRX',
+		imgSrc: zrxSvg,
+		desc: `ZRX is a token that is used to power the 0x protocol.
+		The protocol itself is designed to allow Ethereum tokens to be traded at a
+		low cost directly from your wallet.
+		`,
+	},
+	{
+		name: 'USDC',
+		imgSrc: usdcSvg,
+		desc: `USD Coin (USDC) is a stablecoin fully backed by the US dollar and
+		developed by the CENTRE consortium. USDC can be exchanged for dollars
+		1:1 on Coinbase and other exchanges`,
+	},
+	{
+		name: 'USDT',
+		imgSrc: usdtSvg,
+		desc: `Tether (USDT) is a stablecoin that is pegged to the value of a U.S.
+		dollar. Tether’s issuer claims that USDT is backed by bank reserves and
+		loans which match or exceed the value of USDT in circulation.
+		`,
+	},
+	{
+		name: 'WBTC',
+		imgSrc: wbtcSvg,
+		desc: `Wrapped Bitcoin (WBTC) is an Ethereum token that is intended to 
+		represent Bitcoin (BTC) on the Ethereum blockchain. This version of WBTC on 
+		Compound is no longer being supported, with the community migrating 
+		to WBTC2.
+		`,
+	},
+	{
+		name: 'WBTC2',
+		imgSrc: wbtcSvg,
+		desc: `Wrapped Bitcoin (WBTC2) is an Ethereum token that is intended to 
+		represent Bitcoin (BTC) on the Ethereum blockchain. 
+		This version of WBTC is still being actively supported on Compound.
+		`,
+	},
 ];
 
 //// General chart config

--- a/src/pages/Market/index.js
+++ b/src/pages/Market/index.js
@@ -141,10 +141,17 @@ export default function Market({ match }) {
 							</Column>
 						</ResponsiveRow>
 					</Card>
+					<SectionTitle title={'About ' + activeCoinName} />
+					<CoinInfoCard
+						value={activeCoin.desc}
+						whitepaper={activeCoin.whitepaper}
+						website={activeCoin.website}
+						twitter={activeCoin.twitter}
+						coingecko={activeCoin.coingecko}
+					/>
 				</Column>
 				<Column gap={gap}>
 					<SectionTitle title="Market Overview" />
-					<CoinInfoCard title={'Coin info'} value={activeCoin.desc} />
 					<StatCard
 						title={'Total supplied'}
 						tooltipContent="The total value (USD) of tokens supplied to the market."

--- a/src/pages/Market/index.js
+++ b/src/pages/Market/index.js
@@ -3,7 +3,7 @@ import { Redirect } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import ChartContainer from 'components/chartContainer';
 import { useApyData, useSummaryData } from 'store/hooks';
-import Card, { StatCard, ProgressCard } from 'components/Card';
+import Card, { StatCard, ProgressCard, CoinInfoCard } from 'components/Card';
 import Row, { ResponsiveRow } from 'components/Row';
 import Column from 'components/Column';
 import { Typography } from 'theme';
@@ -144,6 +144,7 @@ export default function Market({ match }) {
 				</Column>
 				<Column gap={gap}>
 					<SectionTitle title="Market Overview" />
+					<CoinInfoCard title={'Coin info'} value={activeCoin.desc} />
 					<StatCard
 						title={'Total supplied'}
 						tooltipContent="The total value (USD) of tokens supplied to the market."

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -29,6 +29,23 @@ export function StyledExternalLink({ href, content }) {
 	);
 }
 
+const StyledExternalInfoLinkWrapper = styled.a`
+	text-decoration: none;
+	color: ${({ theme }) => theme.color.linkInternal};
+	padding-right: ${({ theme }) => theme.spacing.lg};
+	a:active {
+		text-decoration: none;
+	}
+`;
+
+export function StyledExternalInfoLink({ href, content }) {
+	return (
+		<StyledExternalInfoLinkWrapper target="_blank" href={href}>
+			{content}
+		</StyledExternalInfoLinkWrapper>
+	);
+}
+
 export const StyledLogo = styled.img`
 	width: ${({ size }) => size ?? '24px'};
 	height: ${({ size }) => size ?? '24px'};


### PR DESCRIPTION
The use of WBTC and WBTC2 on the site was confusing, so I added a "coin info" box on the markets page. For consistency, I added it for each coin listed. Screenshot: 

<img width="1440" alt="Screen Shot 2021-08-03 at 11 08 02 PM" src="https://user-images.githubusercontent.com/7016669/128130505-f3902f68-e140-4978-b800-20e2b34e925c.png">

Also I added a site description since the current version defaults to the create-react-app description